### PR TITLE
Fix key label order

### DIFF
--- a/.circleci/extend.txt
+++ b/.circleci/extend.txt
@@ -32,5 +32,5 @@ sub-001/ses-01/func/sub-001_ses-01_task-breathhold_rec-pu_bold.json
 sub-001/ses-01/func/sub-001_ses-01_task-breathhold_rec-pu_bold.nii.gz
 sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_bold.json
 sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_bold.nii.gz
-sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_rec-pu_bold.json
-sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_rec-pu_bold.nii.gz
+sub-001/ses-01/func/sub-001_ses-01_task-rest_rec-pu_run-01_bold.json
+sub-001/ses-01/func/sub-001_ses-01_task-rest_rec-pu_run-01_bold.nii.gz

--- a/.circleci/extend.txt
+++ b/.circleci/extend.txt
@@ -30,7 +30,7 @@ sub-001/ses-01/func/sub-001_ses-01_task-breathhold_bold.json
 sub-001/ses-01/func/sub-001_ses-01_task-breathhold_bold.nii.gz
 sub-001/ses-01/func/sub-001_ses-01_task-breathhold_rec-pu_bold.json
 sub-001/ses-01/func/sub-001_ses-01_task-breathhold_rec-pu_bold.nii.gz
-sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_bold.json
-sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_bold.nii.gz
 sub-001/ses-01/func/sub-001_ses-01_task-rest_rec-pu_run-01_bold.json
 sub-001/ses-01/func/sub-001_ses-01_task-rest_rec-pu_run-01_bold.nii.gz
+sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_bold.json
+sub-001/ses-01/func/sub-001_ses-01_task-rest_run-01_bold.nii.gz

--- a/xnat_downloader/cli/run.py
+++ b/xnat_downloader/cli/run.py
@@ -6,6 +6,19 @@ import re
 from subprocess import call
 
 
+SCAN_EXPR = """\
+^(?P<rec>PU:)?\
+(?P<modality>[a-z]+)?\
+(-(?P<label>[a-zA-Z0-9]+))?\
+(_task-(?P<task>[a-zA-Z0-9]+))?\
+(_acq-(?P<acq>[a-zA-Z0-9]+))?\
+(_ce-(?P<ce>[a-zA-Z0-9]+))?\
+(_dir-(?P<dir>[a-zA-Z0-9]+))?\
+(_run-(?P<run>[a-zA-Z0-9]+))?\
+(_echo-(?P<echo>[0-9]+))?\
+"""
+
+
 def parse_json(json_file):
     """
     Parse json file.
@@ -250,12 +263,14 @@ class Subject:
         sub_ses_pattern = re.compile(r'(sub-[A-Za-z0-9]+)_?(ses-[A-Za-z0-9]+)?')
         sub_name, ses_name = re.search(sub_ses_pattern, ses_dir).groups()
 
-        scan_pattern = re.compile(r'(PU:)?([a-z]+)(-[a-zA-Z0-9]+)?(_[a-zA-Z0-9_\-]+$)?')
+        scan_pattern = re.compile(SCAN_EXPR)
 
-        rec, scan_dir, scan_labelr, scan_info = re.search(scan_pattern, scan).groups()
+        # WARNING they will only be in the correct order if I am using
+        # python3.6+
+        scan_pattern_dict = re.search(scan_pattern, scan).groupdict()
 
         # build up the bids directory
-        bids_dir = os.path.join(dest, sub_name, ses_name, scan_dir)
+        bids_dir = os.path.join(dest, sub_name, ses_name, scan_pattern_dict['modality'])
 
         if not os.path.isdir(bids_dir):
             os.makedirs(bids_dir)
@@ -263,23 +278,19 @@ class Subject:
         # name the bids file
         fname = '_'.join([sub_name, ses_name])
 
-        if scan_info is not None:
-            scan_info = scan_info.lstrip('_')
-            fname = '_'.join([fname, scan_info])
+        bids_keys_order = ['task', 'acq', 'ce', 'rec', 'dir', 'run', 'echo']
 
-        if rec is not None:
-            fname = '_'.join([fname, 'rec-pu'])
+        for key in bids_keys_order:
+            label = scan_pattern_dict[key]
+            if key == 'rec' and label is not None:
+                scan_pattern_dict['rec'] = 'pu'
+            fname = '_'.join(fname, key + '-' + label)
+        fname = '_'.join(fname, scan_pattern_dict['label'])
 
-        if scan_labelr is not None:
-            scan_label = scan_labelr.lstrip('-')
-        else:
-            scan_label = scan_dir
-
-        fname = '_'.join([fname, scan_label])
-
-        dcm2niix = 'dcm2niix -o {bids_dir} -f {fname} -z y -b y {dcm_dir}'.format(bids_dir=bids_dir,
-                                                                                  fname=fname,
-                                                                                  dcm_dir=dcm_dir)
+        dcm2niix = 'dcm2niix -o {bids_dir} -f {fname} -z y -b y {dcm_dir}'.format(
+            bids_dir=bids_dir,
+            fname=fname,
+            dcm_dir=dcm_dir)
         bids_outfile = os.path.join(bids_dir, fname + '.nii.gz')
         if not os.path.exists(bids_outfile):
             call(dcm2niix, shell=True)

--- a/xnat_downloader/cli/run.py
+++ b/xnat_downloader/cli/run.py
@@ -284,7 +284,7 @@ class Subject:
             label = scan_pattern_dict[key]
             if label is not None:
                 if key == 'rec':
-                    scan_pattern_dict['rec'] = 'pu'
+                    label = 'pu'
                 fname = '_'.join([fname, key + '-' + label])
 
         # add the label (e.g. _bold)

--- a/xnat_downloader/cli/run.py
+++ b/xnat_downloader/cli/run.py
@@ -288,7 +288,12 @@ class Subject:
                 fname = '_'.join([fname, key + '-' + label])
 
         # add the label (e.g. _bold)
-        fname = '_'.join([fname, scan_pattern_dict['label']])
+        if scan_pattern_dict['label'] is None:
+            label = scan_pattern_dict['modality']
+        else:
+            label = scan_pattern_dict['label']
+
+        fname = '_'.join([fname, label])
 
         dcm2niix = 'dcm2niix -o {bids_dir} -f {fname} -z y -b y {dcm_dir}'.format(
             bids_dir=bids_dir,

--- a/xnat_downloader/cli/run.py
+++ b/xnat_downloader/cli/run.py
@@ -285,10 +285,10 @@ class Subject:
             if label is not None:
                 if key == 'rec':
                     scan_pattern_dict['rec'] = 'pu'
-                fname = '_'.join(fname, key + '-' + label)
+                fname = '_'.join([fname, key + '-' + label])
 
         # add the label (e.g. _bold)
-        fname = '_'.join(fname, scan_pattern_dict['label'])
+        fname = '_'.join([fname, scan_pattern_dict['label']])
 
         dcm2niix = 'dcm2niix -o {bids_dir} -f {fname} -z y -b y {dcm_dir}'.format(
             bids_dir=bids_dir,

--- a/xnat_downloader/cli/run.py
+++ b/xnat_downloader/cli/run.py
@@ -282,9 +282,12 @@ class Subject:
 
         for key in bids_keys_order:
             label = scan_pattern_dict[key]
-            if key == 'rec' and label is not None:
-                scan_pattern_dict['rec'] = 'pu'
-            fname = '_'.join(fname, key + '-' + label)
+            if label is not None:
+                if key == 'rec':
+                    scan_pattern_dict['rec'] = 'pu'
+                fname = '_'.join(fname, key + '-' + label)
+
+        # add the label (e.g. _bold)
         fname = '_'.join(fname, scan_pattern_dict['label'])
 
         dcm2niix = 'dcm2niix -o {bids_dir} -f {fname} -z y -b y {dcm_dir}'.format(


### PR DESCRIPTION
Fixes #6 

This pull request should more intelligently parse the scan names and place the key-labels in the correct order when reconstructing so we don't run into issues surrounding further processing streams that depend on BIDS organized data.